### PR TITLE
Refactor: 하단 탐색 바 활성화 스타일 조건부 렌더링으로 구현

### DIFF
--- a/my-app/src/components/shared/NavBar/NavBarItem.jsx
+++ b/my-app/src/components/shared/NavBar/NavBarItem.jsx
@@ -1,24 +1,24 @@
-import React, { useLayoutEffect, useState, useRef } from "react";
-import { useEffect } from "react";
 import { StyledLink } from "./navBarItem.style";
 
 export default function NavBarItem({ linkSrc, iconSrc, navTxt, currentPath }) {
-    const [isActivated, setIsActivated] = useState(false);
-
-    useEffect(() => {
-        console.log(currentPath === linkSrc);
-        if (currentPath === linkSrc) {
-            setIsActivated(true);
-        }
-    }, []);
-
-    return (
-        <StyledLink
-            to={linkSrc}
-            icon={iconSrc}
-            className={isActivated ? "activated" : ""}
-        >
+    if (currentPath === linkSrc) {
+        return (
+            <StyledLink
+                to={linkSrc}
+                icon={iconSrc}
+                className={"activated"}
+            >
             {navTxt}
-        </StyledLink>
-    );
+            </StyledLink>
+        );
+    } else {
+        return (
+            <StyledLink
+                to={linkSrc}
+                icon={iconSrc}
+            >
+            {navTxt}
+            </StyledLink>
+        );
+    }
 }


### PR DESCRIPTION
처음에는 useState + useEffect를 이용했으나 useEffect의 문제점은 브라우저에 그려진 후 작동하는 거라서 리렌더링 문제가 있을거 같았음 그래서 조건부 렌더링을 이용해 리렌더링을 방지하고자 하는 의도
관련 이슈: #20