### PR TITLE
Fix: 개별 채팅 페이지 데이터가 잘 안 불러와지는 문제 해결 #93

### DIFF
--- a/my-app/src/pages/chat/ChatList.jsx
+++ b/my-app/src/pages/chat/ChatList.jsx
@@ -22,7 +22,6 @@ export default function ChatList() {
                     image={e.caller.image}
                     isOnline={e.caller.isOnline}
                     username={e.caller.username}
-                    data={e.chatData}
                     lastChat={lastChat}
                     date={e.chatData[lastIndex].date}
                 />

--- a/my-app/src/pages/chat/ChattingRoom.jsx
+++ b/my-app/src/pages/chat/ChattingRoom.jsx
@@ -1,9 +1,17 @@
+import { useEffect, useState } from "react";
 import { useLocation } from "react-router";
+import data from "./chat/chatdata.json";
 
 export default function ChattingRoom() {
     const location = useLocation();
-    console.log(location.state.chatData);
+    const [eachChat, setEachChat] = useState();
+    const id = location.pathname.split("/")[2];
 
+    useEffect(() => {
+        setEachChat(data.chat.filter(e => e.id === id)[0]);
+    }, []);
+    
+    console.log(eachChat);
     return (
         <div>ChattingRoom</div>
     )

--- a/my-app/src/pages/chat/chat/ChatItem.jsx
+++ b/my-app/src/pages/chat/chat/ChatItem.jsx
@@ -7,7 +7,6 @@ export default function ChatItem({
     image,
     isOnline,
     username,
-    data,
     lastChat,
     date,
 }) {
@@ -18,7 +17,7 @@ export default function ChatItem({
     // 링크 클릭시 해당 데이터를 그 페이지에 전달하도록 했습니다.
     return (
         <ChatItemCont>
-            <Link className={"link"} to={chatLink} state={{chatData: data}}>
+            <Link className={"link"} to={chatLink}>
                 <div className={isOnline ? "profileImgWrapper online" : "profileImgWrapper"}>
                     {/* 스크린 리더 사용자를 위해 온라인 오프라인 표시를 했습니다. */}
                     <span className={"ir"}>{isOnline ? "온라인" : "오프라인"}</span>


### PR DESCRIPTION
코드 수정 전: 개별 채팅 페이지로 이동하는 링크를 누르지 않고 직접 페이지 링크를 입력 후 이동시 데이터가 안 불러와지는 문제가 있었음
코드 해결: 개별 채팅 페이지에서 데이터를 받아와 filter를 이용해 개별 채팅 데이터 추출