### PR TITLE
Feat: 로그인 후 프로필 설정 페이지 - 기존 정보 불러오기 #102

### DIFF
--- a/my-app/src/components/ProfileImageSet/ProfileImageSet.jsx
+++ b/my-app/src/components/ProfileImageSet/ProfileImageSet.jsx
@@ -2,7 +2,7 @@ import React, { useRef } from "react";
 import ImageUpload from "../ImageUpload/ImageUpload.jsx";
 import { ProfileImgSetCont } from "./profileImageSet.style.js";
 
-export default function ProfileImageSet({ onChangeByUpper }) {
+export default function ProfileImageSet({ onChangeByUpper, initial }) {
     const image = useRef(null);
 
     const handleFiles = (files, fileReader) => {
@@ -18,7 +18,7 @@ export default function ProfileImageSet({ onChangeByUpper }) {
             <span className={"ir"}>프로필 사진 이미지 설정</span>
             <img
                 className={"profileImg"}
-                src={require(`../../assets/basic-profile-img.png`)}
+                src={initial || require(`../../assets/basic-profile-img.png`)}
                 alt=""
                 ref={image}
             />

--- a/my-app/src/components/ProfileSetInpsTemp/ProfileSetInpsTempLogIn.jsx
+++ b/my-app/src/components/ProfileSetInpsTemp/ProfileSetInpsTempLogIn.jsx
@@ -1,0 +1,197 @@
+import React, { useState, useRef, useEffect } from "react";
+import axios from "axios";
+import ProfileImageSet from "../ProfileImageSet/ProfileImageSet";
+import UserInput from "../userinput/UserInput";
+import Inp from "../userinput/Inp";
+import ProfileSetCont from "./profileSetINpsTemp.style";
+import Warning from "../Warning";
+
+export default function ProfileSetTemp({
+    formId,
+    prev,
+    onInValidByUpper,
+    onValidByUpper,
+    onSubmitByUpper,
+}) {
+    const [initial, setInitial] = useState(null);
+
+    const accountName = useRef(null);
+    const accountId = useRef(null);
+    const about = useRef(null);
+    const nameAlert = useRef(null);
+    const idAlert = useRef(null);
+    const submitData = useRef({});
+
+    useEffect(() => {
+        if (Object.keys(prev).length > 0) {
+            accountName.current.value = prev.username;
+            accountId.current.value = prev.accountname;
+            about.current.value = prev.intro;
+            setInitial(prev.image);
+        }
+    }, [prev]);
+
+
+    // 이름 인풋창에서 포커스 아웃시 동작하는 함수
+    const onNameBlurHandle = (e) => {
+        if (
+            e.target.validity.patternMismatch ||
+            e.target.value.trim().length === 0
+        ) {
+            // 이름 패턴이 유효하지 않을 경우
+            nameAlert.current.style.display = "block";
+
+            onInValidByUpper(); // 제출 버튼 비활성화
+        } else {
+            // 이름 패턴이 유효할 경우
+            nameAlert.current.style.display = "none";
+            if (
+                // 모든 인풋창에 값이 있고 아이디 경고창이 없을 때(아이디가 유효할 때)
+                accountName.current.value &&
+                accountId.current.value &&
+                idAlert.current.style.display === "none"
+            ) {
+                onValidByUpper(); // 제출 버튼 활성화
+            }
+        }
+    };
+
+    // 아이디 인풋창에서 포커스 아웃시 동작하는 함수
+    const onIdBlurHandle = async (e) => {
+        if (e.target.validity.patternMismatch) {
+            // 아이디 패턴이 유효하지 않을 경우
+            idAlert.current.style.display = "block";
+
+            onInValidByUpper(); // 제출 버튼 비활성화
+        } else if (prev && e.target.value === prev.accountname) {
+            // 예전 아이디랑 지금 아이디랑 같을 경우
+            idAlert.current.style.display = "none";
+            return;
+        } else {
+            // 아이디 패턴이 유효할 경우
+            try {
+                // 아이디 중복 검증
+                const res = await axios.post(
+                    "https://mandarin.api.weniv.co.kr/user/accountnamevalid",
+                    {
+                        user: {
+                            accountname: accountId.current.value,
+                        },
+                    },
+                    {
+                        headers: {
+                            "Content-type": "application/json",
+                        },
+                    }
+                );
+
+                if (res.data.message === "이미 가입된 계정ID 입니다.") {
+                    idAlert.current.textContent = ("*" + res.data.message);
+                    idAlert.current.style.display = "block";
+
+                    onInValidByUpper(); // 제출 버튼 비활성화
+                } else {
+                    // 중복 계정이 아닐 경우
+                    idAlert.current.style.display = "none";
+
+                    if (
+                        // 모든 인풋에 값이 있고 이름 경고창이 없는 경우(이름이 유효한 경우) 제출 버튼 활성화
+                        accountName.current.value &&
+                        accountId.current.value &&
+                        nameAlert.current.style.display === "none"
+                    ) {
+                        onValidByUpper();
+                    }
+                }
+            } catch (error) {
+                console.log(error);
+            }
+        }
+    };
+
+    // 이미지 파일 변경시 동작하는 함수
+    const ImgChangeHandle = async (imgdata) => {
+        const formData = new FormData();
+        formData.append("image", imgdata);
+        submitData.current["imageBeforeSubmit"] = formData;
+        console.log(submitData.current);
+    };
+
+    // 폼 제출시 동작하는 함수
+    const onSubmitHandle = async (e) => {
+        e.preventDefault();
+        if (submitData.current.imageBeforeSubmit) {
+            try {
+                const res = await fetch(
+                    "https://mandarin.api.weniv.co.kr/image/uploadfile",
+                    {
+                        method: "POST",
+                        body: submitData.current.imageBeforeSubmit,
+                    }
+                );
+                const json = await res.json();
+    
+                submitData.current["image"] =
+                    "https://mandarin.api.weniv.co.kr/" + json.filename;
+                submitData.current["username"] = accountName.current.value;
+                submitData.current["accountname"] = accountId.current.value;
+                submitData.current["intro"] = about.current.value;
+                onSubmitByUpper(submitData);
+                console.log("프로필 수정 성공 - 1");
+            } catch (err) {
+                console.log(err);
+            }
+        } else {
+            submitData.current["username"] = accountName.current.value;
+            submitData.current["accountname"] = accountId.current.value;
+            submitData.current["intro"] = about.current.value;
+            onSubmitByUpper(submitData);
+            console.log("프로필 수정 성공 - 2");
+        }
+    };
+
+    return (
+        <ProfileSetCont id={formId} onSubmit={onSubmitHandle}>
+            <ProfileImageSet initial={initial} onChangeByUpper={ImgChangeHandle} />
+            <UserInput inputId={"userName"} label={"사용자 이름"}>
+                <Inp
+                    className={"inp"}
+                    onBlur={onNameBlurHandle}
+                    type={"text"}
+                    id={"userName"}
+                    ref={accountName}
+                    placeholder={"2~10자 이내여야 합니다."}
+                    minLength={"2"}
+                    maxLength={"10"}
+                    pattern={"[a-zA-Zㄱ-힣 ]{2,10}"}
+                    required
+                />
+            </UserInput>
+            <Warning ref={nameAlert} className={"warn"}>* 한글 또는 영어를 2~10자 이내로 입력하세요.</Warning>
+            <UserInput inputId={"accountID"} label={"계정 ID"}>
+                <Inp
+                    className={"inp"}
+                    onBlur={onIdBlurHandle}
+                    type={"text"}
+                    id={"accountID"}
+                    ref={accountId}
+                    placeholder={
+                        "영문, 숫자, 특수문자(.),(_)만 사용 가능합니다."
+                    }
+                    pattern={"[a-zA-Z0-9._]+"}
+                    required
+                />
+            </UserInput>
+            <Warning ref={idAlert} className={"warn"}>* 영문, 숫자, 밑줄 및 마침표만 사용할 수 있습니다.</Warning>
+            <UserInput inputId={"about"} label={"소개"}>
+                <Inp
+                    className={"inp"}
+                    type={"text"}
+                    id={"about"}
+                    ref={about}
+                    placeholder={"자신과 판매할 상품에 대해 소개해 주세요!"}
+                />
+            </UserInput>
+        </ProfileSetCont>
+    );
+}

--- a/my-app/src/pages/profile/follow/EditProfile.jsx
+++ b/my-app/src/pages/profile/follow/EditProfile.jsx
@@ -1,24 +1,22 @@
-import React, { useState } from "react";
+import React, { useEffect, useState, useCallback } from "react";
 import axios from "axios";
 import TopBar from "../../../components/TopBar";
-import ProfileSetInpsTemp from "../../../components/ProfileSetInpsTemp/ProfileSetInpsTemp";
+import ProfileSetInpsTempLogIn from "../../../components/ProfileSetInpsTemp/ProfileSetInpsTempLogIn";
 
 export default function EditProfile() {
+    const [isBtnVisible, setIsBtnVisible] = useState(false);
+    const [prevData, setPrevData] = useState({});
+
     const token = localStorage.getItem("token");
 
-    const [isBtnVisible, setIsBtnVisible] = useState(true);
-
-    // 제출 버튼을 비활성화 하는 함수: 하위 컴포넌트에 내려줄 거임
     const onInvalidFunc = () => {
         setIsBtnVisible(true);
     };
 
-    // 제출 버튼을 활성화 하는 함수: 하위 컴포넌트에 내려줄 거임
     const onValidFunc = () => {
         setIsBtnVisible(false);
     };
 
-    // 폼이 제출될 때 실행되는 함수
     const onSubmitFunc = async (submitted) => {
         // 원본 데이터를 훼손하지 않기 위해 스프레드 기법 + 새로운 변수를 만듦, 기존 데이터 건들지 않는 방향으로
         let edited;
@@ -42,11 +40,11 @@ export default function EditProfile() {
             const loginRes = await axios.put(
                 "https://mandarin.api.weniv.co.kr/user",
                 {
-                    "user":edited
+                    user: edited,
                 },
                 {
                     headers: {
-                        "Authorization": `Bearer ${token}`,
+                        Authorization: `Bearer ${token}`,
                         "Content-type": "application/json",
                     },
                 }
@@ -58,14 +56,43 @@ export default function EditProfile() {
         }
     };
 
+    // 페이지 로드시 기존 정보를 가져오기 위함
+    const getPrevData = useCallback(async () => {
+        try {
+            const res = await axios.get(
+                "https://mandarin.api.weniv.co.kr/user/myinfo",
+                {
+                    headers: {
+                        Authorization: `Bearer ${token}`,
+                    },
+                }
+            );
+
+            // 기존 정보를 가져온 뒤 prevData에 값을 넣음
+            setPrevData({
+                username: res.data.user.username,
+                accountname: res.data.user.accountname,
+                intro: res.data.user.intro,
+                image: res.data.user.image
+            });
+        } catch (err) {
+            console.log(err);
+        }
+    }, [token]);
+
+    useEffect(() => {
+        getPrevData();
+    }, [getPrevData]);
+
     return (
         <>
             <TopBar
                 type={"A4"}
-                right4Ctrl={{ form: "login", isDisabled: { isBtnVisible } }}
+                right4Ctrl={{ form: "logined", isDisabled: { isBtnVisible } }}
             />
-            <ProfileSetInpsTemp
-                formId={"login"}
+            <ProfileSetInpsTempLogIn
+                formId={"logined"}
+                prev={prevData}
                 onInValidByUpper={onInvalidFunc}
                 onValidByUpper={onValidFunc}
                 onSubmitByUpper={onSubmitFunc}


### PR DESCRIPTION
기존 명세와 다른 점: 처음에 저장 버튼을 활성화해놓고 만약 사용자가 invalid한 값을 인풋창에 입력후 포커스 아웃시 저장 버튼이 비활성화 되도록 ProfileImageSet 컴포넌트의 img src 기본값을 기본 이미지로 해놓고, initial props를 받아온 경우(로그인 후 프로필 설정 페이지) 받아온 이미지를 띄우도록 함