### PR TITLE
Feat/issue 130

### DIFF
--- a/my-app/src/components/TopBar.jsx
+++ b/my-app/src/components/TopBar.jsx
@@ -69,11 +69,11 @@ export default function TopBar({type, title, right4Ctrl, onChangeByUpper, onClic
     return (
         <TopBarCont>
             <LeftCont>
-                {TypeLeft === "A" && !title ? <BtnIcon action="back"/> : <></>}
+                {TypeLeft === "A" && !title ? <BtnIcon action="back" onClick={() => navigate(-1)}/> : <></>}
                 {TypeLeft === "B" && title ? <div>{title}</div> : <></>}
                 {TypeLeft === "A" && title ?
                 <>
-                    <BtnIcon action="back"/>
+                    <BtnIcon action="back" onClick={() => navigate(-1)}/>
                     <div>{title}</div>
                 </> :
                 <></>}

--- a/my-app/src/pages/account/Register.jsx
+++ b/my-app/src/pages/account/Register.jsx
@@ -91,7 +91,7 @@ export default function Register() {
         "password": pwVal,
         "accountname": null, 
         "intro": null, 
-        "image": "https://mandarin.api.weniv.co.kr/Ellipse.png"
+        "image": "https://mandarin.api.weniv.co.kr/1671499060657.png"
       }
     })
   }, [idValid, pwValid])

--- a/my-app/src/pages/feed/UploadProduct.jsx
+++ b/my-app/src/pages/feed/UploadProduct.jsx
@@ -7,11 +7,15 @@ import UserInput from '../../components/userinput/UserInput';
 import Button from '../../components/Button';
 import ImageUpload from "../../components/ImageUpload/ImageUpload";
 import { ProductImgSetCont } from "../../components/ProductImageSet/productImageSet.style";
+import Warning from '../../components/Warning';
 
 export default function UploadProduct() {
     const [productName, setProductName] = useState('')
     const [productPrice, setProductPrice] = useState('')
     const [productLink, setProductLink] = useState('')
+    const nameAlertMsg = useRef(null);
+    const priceAlertMsg = useRef(null);
+    const linkAlertMsg = useRef(null);
     const imagePre = useRef(null)
     const handleInpName = (e) => {
         setProductName(e.target.value)
@@ -76,7 +80,23 @@ export default function UploadProduct() {
                 });
                 const json = await response.json();
                 console.log(json);
-                console.log("상품 등록 완료");
+
+                if (json.message === "필수 입력사항을 입력해주세요."){
+                    (!productName) ? 
+                        nameAlertMsg.current.style.display = "block" : 
+                        nameAlertMsg.current.style.display = "none";
+
+                    (!productPrice) ? 
+                        priceAlertMsg.current.style.display = "block":
+                        priceAlertMsg.current.style.display = "none";
+                    
+                    (!productLink) ? 
+                        linkAlertMsg.current.style.display = "block" : 
+                        linkAlertMsg.current.style.display = "none";
+                }
+                else {
+                    console.log("상품 등록 완료");
+                }
             }());
         } catch (err) {
             console.log(err);
@@ -115,6 +135,7 @@ export default function UploadProduct() {
                 >
                 </Inp>
             </UserInput>
+            <Warning ref={nameAlertMsg}>* 상품명을 입력해주세요.</Warning>
             <UserInput inputId="productPrice" label="가격">
                 <Inp
                     type="number"
@@ -125,6 +146,7 @@ export default function UploadProduct() {
                 >
                 </Inp>
             </UserInput>
+            <Warning ref={priceAlertMsg}>* 가격을 입력해주세요.</Warning>
             <UserInput inputId="productLink" label="판매링크">
                 <Inp
                     type="url"
@@ -135,6 +157,7 @@ export default function UploadProduct() {
                 >
                 </Inp>
             </UserInput>
+            <Warning ref={linkAlertMsg}>* 판매 링크를 입력해주세요.</Warning>
             <Button
                 type="button"
                 className="ms"

--- a/my-app/src/pages/profile/follow/Follower.jsx
+++ b/my-app/src/pages/profile/follow/Follower.jsx
@@ -4,6 +4,7 @@ import axios from 'axios'
 import { useState, useContext, useEffect } from 'react'
 import FollowListCard from './FollowListCard'
 import { useParams } from 'react-router';
+import NoFollowerFollowing from './NoFollowerFollowing';
 
 export default function Following() {   
     const [resMsg, setResMsg] = useState([]);
@@ -35,9 +36,9 @@ useEffect(() => {
     }
   }, [resMsg])
   
-    return (
-        <ul>
-          {followerArr}
-        </ul>
-  )
+  return (followerArr.length === 0) ?
+    <NoFollowerFollowing page="follower"/>:
+    <ul>
+      {followerArr}
+    </ul>
 }

--- a/my-app/src/pages/profile/follow/Following.jsx
+++ b/my-app/src/pages/profile/follow/Following.jsx
@@ -4,6 +4,7 @@ import axios from 'axios'
 import { useState, useContext, useEffect } from 'react'
 import FollowListCard from './FollowListCard'
 import { useParams } from 'react-router';
+import NoFollowerFollowing from './NoFollowerFollowing';
 
 export default function Following() {   
     const [resMsg, setResMsg] = useState([]);
@@ -35,9 +36,10 @@ useEffect(() => {
     }
   }, [resMsg])
   
-    return (
-        <ul>
-         {followingArr}
-        </ul>
-  )
+
+  return (followingArr.length === 0) ?
+    <NoFollowerFollowing page="following"/> :
+    <ul>
+      {followingArr}
+    </ul>
 }

--- a/my-app/src/pages/profile/follow/NoFollowerFollowing.jsx
+++ b/my-app/src/pages/profile/follow/NoFollowerFollowing.jsx
@@ -1,0 +1,17 @@
+import React from 'react'
+import { useNavigate } from 'react-router'
+import Button from '../../../components/Button';
+import TopBar from '../../../components/TopBar';
+
+export default function NoFollowerFollowing(props) {
+    const navigate = useNavigate();
+    
+    return (
+        
+        <div>
+            <TopBar type="AO"/>
+            {props.page === "follower" ? <>팔로우하는 유저가 없습니다</>: <>팔로잉하는 유저가 없습니다.</>}
+            <Button className='large' onClick={()=> navigate("../../../search")}>탐색하기</Button>
+        </div>
+    )
+}

--- a/my-app/src/pages/profile/userprofile/SaledProductCard.jsx
+++ b/my-app/src/pages/profile/userprofile/SaledProductCard.jsx
@@ -12,8 +12,8 @@ const Cont = styled.div`
     `;
     
 const Window = styled.div`
-    overflow: hidden;
-    height: 140px;
+    overflow: scroll;
+    height: 150px;
 `;
 
 const SaledProduct = styled.h2`


### PR DESCRIPTION
- 프로필 페이지에서 판매 상품 깜빡거림 수정
    - 판매상품 목록 캐러셀 깜빡거림 이슈
    - overflow: scroll 으로 대체
    - ![image](https://user-images.githubusercontent.com/78977003/208568644-2b575d89-b10d-4505-9c7b-1fc0d3c17b25.png)

- 상품 등록 유효성 검증 추가
    - 비어있는 필드가 있을 때 경고 메시지 디스플레이
    - <img width="232" alt="image" src="https://user-images.githubusercontent.com/78977003/208568016-e92378ef-344c-4e53-be94-ae75325409c2.png">

- 팔로잉 & 팔로워 수가 0일때 예외처리
    - 팔로잉 & 팔로우 수가 0일때는 다르게 렌더링되도록 함
    - 페이지 스타일링 추후 필요
    - <img width="595" alt="image" src="https://user-images.githubusercontent.com/78977003/208568279-c1883ab8-d411-44b6-b56b-47f1e0f4bfa6.png">

- 상단 바에서 뒤로 가기 클릭 시 이전 페이지로 이동
    - <img width="589" alt="image" src="https://user-images.githubusercontent.com/78977003/208568378-5d0b5242-a537-49e1-a0ba-2b30a98e95dc.png">

- 회원가입 시 기본 프로필 사진 변경
    - <img width="269" alt="image" src="https://user-images.githubusercontent.com/78977003/208568514-51ac8552-f5f8-4e16-aa1f-c664af35f009.png">
