### PR TITLE
Fix: 판매 상품 이동 url 수정 #139

### DIFF
--- a/my-app/src/pages/profile/userprofile/SaledProductCard.jsx
+++ b/my-app/src/pages/profile/userprofile/SaledProductCard.jsx
@@ -85,8 +85,8 @@ useEffect(() => {
 
 // 판매중인 상품의 링크로 넘어가는 부분입니다.
 const handlelink = (link) => {
-        navigate(link);
-    }  
+        window.open("http://" + link, '_blank')
+}  
 
 // 상품을 뿌려주는 역할을 하는 부분입니다.
 useEffect(() => {


### PR DESCRIPTION
- 프로필 페이지에서 판매 상품 클릭 시 url 설정 오류 해결
<img width="335" alt="image" src="https://user-images.githubusercontent.com/78977003/208582917-39e16c67-1467-45c7-87b6-3f71296dd2e7.png">

- 앞에 'http://'추가 하여 해결
- 새 탭으로 열도록 수정