### PR TITLE
Feat: 자신의 프로필에서 수정 버튼 클릭시 모달창이 나오고 게시글을 수정할 수 있도록 #138

### DIFF
--- a/my-app/src/components/PostCard.jsx
+++ b/my-app/src/components/PostCard.jsx
@@ -1,152 +1,175 @@
 /* eslint-disable */
 /* eslint-disable array-callback-return */
-import React from 'react'
-import { useState, useEffect } from 'react';
-import { Link } from 'react-router-dom';
-import  heart_active  from '../assets/icon/icon-heart-active.png';
-import  heart  from '../assets/icon/icon-heart.png';
-import comment from '../assets/icon/icon-message-circle.png';
-import styled from 'styled-components';
-import axios from 'axios';
+import React from "react";
+import { useState, useEffect } from "react";
+import { Link } from "react-router-dom";
+import OptionModal from "./OptionModal/OptionModal";
+import heart_active from "../assets/icon/icon-heart-active.png";
+import heart from "../assets/icon/icon-heart.png";
+import comment from "../assets/icon/icon-message-circle.png";
+import styled from "styled-components";
+import axios from "axios";
 // import Heart from './Heart';
 const Cont = styled.div`
-        display: flex;
-        margin-top: 20px;
-    `;
-    const Username = styled.h2`
-        font-weight: 600;
-        font-size: 14px;
-        line-height: 18px;
-    `;
+    display: flex;
+    margin-top: 20px;
+`;
+const Username = styled.h2`
+    font-weight: 600;
+    font-size: 14px;
+    line-height: 18px;
+`;
 
-    const Accountname = styled.p`
-        font-weight: 400;
-        font-size: 12px;
-        line-height: 14px;
-        color: #767676;
-        margin-top: 2px;
-    `;
+const Accountname = styled.p`
+    font-weight: 400;
+    font-size: 12px;
+    line-height: 14px;
+    color: #767676;
+    margin-top: 2px;
+`;
 
-    const Content = styled.p`
-        font-weight: 400;
-        font-size: 14px;
-        line-height: 18px;
-        margin-top: 16px;
-    `;
+const Content = styled.p`
+    font-weight: 400;
+    font-size: 14px;
+    line-height: 18px;
+    margin-top: 16px;
+`;
 
-    const Contentimg = styled.img`
-        width: 304px;
-        height: 228px;
-        border: 0.5px solid #DBDBDB;
-        border-radius: 10px;
-        margin-top: 16px;
-    `;
+const Contentimg = styled.img`
+    width: 304px;
+    height: 228px;
+    border: 0.5px solid #dbdbdb;
+    border-radius: 10px;
+    margin-top: 16px;
+`;
 
-    const ContentCont = styled.div`
-        width: 304px;
-    `;
+const ContentCont = styled.div`
+    width: 304px;
+`;
 
-    const Count = styled.span`
-        font-weight: 400;
-        font-size: 12px;
-        line-height: 12px;
-        color: #767676;
-        margin-left: 7px;
-        margin-bottom: 2px;
-        
-    `;
+const Count = styled.span`
+    font-weight: 400;
+    font-size: 12px;
+    line-height: 12px;
+    color: #767676;
+    margin-left: 7px;
+    margin-bottom: 2px;
+`;
 
-    const HeartCommentCont = styled.div`
-        margin-top: 14px;
-    `;
-    const Heartimg = styled.img`
-        width: 15px;
-        height: 15px;
-    `;
+const HeartCommentCont = styled.div`
+    margin-top: 14px;
+`;
+const Heartimg = styled.img`
+    width: 15px;
+    height: 15px;
+`;
 
-    const Commentimg = styled.img`
-        width: 15px;
-        height: 15px;
-        margin-left: 18px;
-    `;
+const Commentimg = styled.img`
+    width: 15px;
+    height: 15px;
+    margin-left: 18px;
+`;
 
-    const Createdate = styled.span`
-        font-weight: 400;
-        font-size: 10px;
-        line-height: 12px;
-        color: #767676;
-        margin-top: 18px;
-    `;
-    const ProfilePicSmall = styled.img`
-        width: 42px;
-        height: 42px;
-        margin-right: 12px;
-    `
+const Createdate = styled.span`
+    font-weight: 400;
+    font-size: 10px;
+    line-height: 12px;
+    color: #767676;
+    margin-top: 18px;
+`;
+const ProfilePicSmall = styled.img`
+    width: 42px;
+    height: 42px;
+    margin-right: 12px;
+`;
 
-export default function PostCard({data, myProfile, view, postDetailSrc}) {
+export default function PostCard({ data, myProfile, view, postDetailSrc }) {
     const [myheart, setMyheart] = useState(data.hearted);
     const [myposthearts, setMyposthearts] = useState(data.heartCount);
-    
+    const [isOptionVisible, setIsOptionVisible] = useState(false);
+
     console.log(myProfile);
     console.log(view);
     const heartchange = async () => {
-        if(myheart === false){
-          setMyheart(true);
-          const hearttrue = await axios.post(
-            `https://mandarin.api.weniv.co.kr/post/${data.id}/heart`,{},{
-            headers: {
-                // Authorization: "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjYzOTY5MWQwMTdhZTY2NjU4MWMzMjM1YyIsImV4cCI6MTY3NTk5NjE5MywiaWF0IjoxNjcwODEyMTkzfQ.yX_F68SQOJkak0ud8BUTI3OUHriaIlPqEqDUiWBcf6I"
-              Authorization: localStorage.getItem("Authorization")
+        if (myheart === false) {
+            setMyheart(true);
+            const hearttrue = await axios.post(
+                `https://mandarin.api.weniv.co.kr/post/${data.id}/heart`,
+                {},
+                {
+                    headers: {
+                        // Authorization: "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjYzOTY5MWQwMTdhZTY2NjU4MWMzMjM1YyIsImV4cCI6MTY3NTk5NjE5MywiaWF0IjoxNjcwODEyMTkzfQ.yX_F68SQOJkak0ud8BUTI3OUHriaIlPqEqDUiWBcf6I"
+                        Authorization: localStorage.getItem("Authorization"),
+                    },
                 }
-            });
-          setMyposthearts(hearttrue.data.post.heartCount);
-        }else{
-          setMyheart(false);
-          const heartfalse = await axios.delete(
-            `https://mandarin.api.weniv.co.kr/post/${data.id}/unheart`,{
-            headers: {
-                // Authorization: "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjYzOTY5MWQwMTdhZTY2NjU4MWMzMjM1YyIsImV4cCI6MTY3NTk5NjE5MywiaWF0IjoxNjcwODEyMTkzfQ.yX_F68SQOJkak0ud8BUTI3OUHriaIlPqEqDUiWBcf6I"
-              Authorization: localStorage.getItem("Authorization")
+            );
+            setMyposthearts(hearttrue.data.post.heartCount);
+        } else {
+            setMyheart(false);
+            const heartfalse = await axios.delete(
+                `https://mandarin.api.weniv.co.kr/post/${data.id}/unheart`,
+                {
+                    headers: {
+                        // Authorization: "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjYzOTY5MWQwMTdhZTY2NjU4MWMzMjM1YyIsImV4cCI6MTY3NTk5NjE5MywiaWF0IjoxNjcwODEyMTkzfQ.yX_F68SQOJkak0ud8BUTI3OUHriaIlPqEqDUiWBcf6I"
+                        Authorization: localStorage.getItem("Authorization"),
+                    },
                 }
-            });
+            );
             setMyposthearts(heartfalse.data.post.heartCount);
         }
-    }
-    console.log(data)
+    };
+    console.log(data);
     return (
-        <Cont>
-            <ProfilePicSmall src= {data.author.image} alt="글쓴이프로필사진" />
-            <ContentCont>
-                <Username>{data.author.username}</Username>
-                <Accountname>@ {data.author.accountname}</Accountname>
-                {myProfile ? <button>수정</button> : <></>}
-                <Content>{data.content}</Content>
-                {(data.image) ? <Contentimg src={data.image} alt="컨텐츠 사진" />
-                 : null}
-                <HeartCommentCont>
-                    <span onClick={heartchange}>
-                        {
-                        myheart ? 
-                        <>
-                          <Heartimg src={heart_active} alt="채워진 하트" /> 
-                          <Count>{myposthearts}</Count>
-                        </>
-                        : 
-                        <>
-                          <Heartimg src={heart} alt="비워진 하트"/>
-                          <Count>{myposthearts}</Count> 
-                          
-                        </>
-                        }
-                    </span>
-                    <Link to={postDetailSrc}>
-                        <span className={"ir"}>게시글 상세 페이지로 이동</span>
-                        <Commentimg src={comment} alt="댓글 아이콘"/>
-                        <Count>{data.commentCount}</Count>
-                    </Link>
-                </HeartCommentCont>
-                <Createdate>{data.createdAt.slice(0,10)}</Createdate>
-            </ContentCont>
-        </Cont>        
-    )
+        <>
+            {isOptionVisible && (
+                <OptionModal onConfirm={() => setIsOptionVisible(false)}>
+                    <li>삭제</li>
+                    <li>
+                        <Link to={`/post/${data.id}/edit`}>수정</Link>
+                    </li>
+                </OptionModal>
+            )}
+            <Cont>
+                <ProfilePicSmall
+                    src={data.author.image}
+                    alt="글쓴이프로필사진"
+                />
+                <ContentCont>
+                    <Username>{data.author.username}</Username>
+                    <Accountname>@ {data.author.accountname}</Accountname>
+                    {myProfile ? <button onClick={() => setIsOptionVisible(true)}>수정</button> : <></>}
+                    <Content>{data.content}</Content>
+                    {data.image ? (
+                        <Contentimg src={data.image} alt="컨텐츠 사진" />
+                    ) : null}
+                    <HeartCommentCont>
+                        <span onClick={heartchange}>
+                            {myheart ? (
+                                <>
+                                    <Heartimg
+                                        src={heart_active}
+                                        alt="채워진 하트"
+                                    />
+                                    <Count>{myposthearts}</Count>
+                                </>
+                            ) : (
+                                <>
+                                    <Heartimg src={heart} alt="비워진 하트" />
+                                    <Count>{myposthearts}</Count>
+                                </>
+                            )}
+                        </span>
+                        <Link to={postDetailSrc}>
+                            <span className={"ir"}>
+                                게시글 상세 페이지로 이동
+                            </span>
+                            <Commentimg src={comment} alt="댓글 아이콘" />
+                            <Count>{data.commentCount}</Count>
+                        </Link>
+                    </HeartCommentCont>
+                    <Createdate>{data.createdAt.slice(0, 10)}</Createdate>
+                </ContentCont>
+            </Cont>
+        </>
+    );
 }

--- a/my-app/src/pages/feed/PostEdit.jsx
+++ b/my-app/src/pages/feed/PostEdit.jsx
@@ -1,0 +1,194 @@
+import { useState, useRef, useEffect } from "react";
+import { useLocation } from "react-router-dom";
+import Button from "../../components/Button";
+import axios from "axios";
+import { ProductImgSetCont } from "../../components/ProductImageSet/productImageSet.style";
+import { ImgUploadIcon } from "../../components/ImageUpload/imageUpload.style";
+
+export default function PostEdit() {
+    const [showImages, setShowImages] = useState([]);
+    const [contentText, setContentText] = useState("");
+    const [isBtnDisable, setIsBtnDisable] = useState(false);
+    const submitData = useRef({});
+    const imagePre = useRef(null);
+    const URL = `https://mandarin.api.weniv.co.kr${useLocation().pathname.slice(0, -5)}`;
+
+    // 페이지 로드시 기존 게시글 정보 불러오기 위함
+    useEffect(() => {
+        const getPrevDetail = async () => {
+            try {
+                const res = await axios.get(URL, {
+                    headers: {
+                        Authorization: localStorage.getItem("Authorization"),
+                        "Content-type": "application/json",
+                    },
+                });
+                console.log(res.data);
+
+                // textarea 기존 데이터 받아온 거로
+                setContentText(res.data.post.content);
+
+                setShowImages((prev) => {
+                    // 받아온 기존 데이터에 이미지가 있을 경우에만 이미지 렌더링
+                    if (res.data.post.image) {
+                        return [...prev, res.data.post.image];
+                    } else return prev;
+                });
+
+                // 기존 데이터 이미지를 나중에 게시글 수정 업로드 요청시 제출할 데이터에 넣도록(이미지 서버에 이미 등록돼있으니까 요청할 필요 없음)
+                submitData.current.image = res.data.post.image;
+                console.log(submitData.current.image);
+            } catch (err) {
+                console.log(err);
+            }
+        };
+
+        getPrevDetail();
+    }, []);
+
+    const handleTextarea = (e) => {
+        setContentText(e.target.value);
+        if (e.target.value.length === 0 && showImages.length === 0) {
+            setIsBtnDisable(true);
+        }
+    };
+
+    // 이미지 브라우저 화면에 업로드 & FormData 형식으로 변환
+    const handleAddImages = (event) => {
+        console.log(showImages);
+        const imageLists = event.target.files;
+        let imageUrlLists = [...showImages];
+        const fileReader = new FileReader();
+
+        for (let i = 0; i < imageLists.length; i++) {
+            imageUrlLists.push(imageLists[i].name);
+            console.log(imageUrlLists);
+            fileReader.readAsDataURL(imageLists[i]);
+            fileReader.onload = function () {
+                imagePre.current.src = fileReader.result;
+                const formData = new FormData();
+                formData.append("image", imageLists[i]);
+                submitData.current["imageBeforeSubmit"] = formData;
+            };
+        }
+
+        if (imageUrlLists.length > 10) {
+            imageUrlLists = imageUrlLists.slice(0, 10);
+        }
+
+        setShowImages(imageUrlLists);
+    };
+
+    const handleDeleteImage = (id) => {
+        setShowImages(showImages.filter((_, index) => index !== id));
+        console.log(submitData.current.image);
+        // 일단 이미지를 하나만 처리한다고 가정해서 버튼 클릭시 모두 null로 바꿨는데 여러장 이미지 등록할 때는 이 코드를 바꿔야 합니다.
+        // 코드 수정 방향: 이미지 삭제 버튼 클릭시 해당 이미지만 삭제하도록(제출할 데이터에서)
+        submitData.current.image = null;
+        console.log(submitData.current.image);
+        console.log(!!contentText);
+        console.log(showImages);
+        console.log(showImages.length);
+        if (!contentText && showImages.length === 1) {
+            setIsBtnDisable(true);
+        }
+    };
+
+    // 업로드 버튼 클릭 시 텍스트, 이미지를 서버로 전송.
+    const onClickUpload = async (e) => {
+        e.preventDefault();
+        console.log(submitData.current.imageBeforeSubmit);
+        console.log(submitData.current.image);
+        console.log("업로드 버튼 클릭");
+        // 이미지 서버에 전송
+
+        try {
+            // imagebeforesubmit이 있는 경우에만 이미지 서버 등록 요청이 되도록(이미지 없이 업로드 위함)
+            if (submitData.current.imageBeforeSubmit) {
+                const res = await fetch(
+                    "https://mandarin.api.weniv.co.kr/image/uploadfile",
+                    {
+                        method: "POST",
+                        body: submitData.current.imageBeforeSubmit,
+                    }
+                );
+                const json = await res.json();
+
+                console.log(json);
+
+                submitData.current["image"] =
+                    "https://mandarin.api.weniv.co.kr/" + json.filename;
+
+                console.log(submitData.current);
+            }
+
+            // 텍스트, 이미지 값 서버에 전송. 이미지는 서버에 있는 데이터를 가져와서 전송.
+            (async function () {
+                const productData = {
+                    post: {
+                        content: contentText,
+                        image: submitData.current["image"],
+                    },
+                };
+                const response = await fetch(URL, {
+                    method: "PUT",
+                    headers: {
+                        Authorization: localStorage.getItem("Authorization"),
+                        "Content-type": "application/json",
+                    },
+                    body: JSON.stringify(productData),
+                });
+                const json = await response.json();
+                console.log(json);
+                console.log("게시글 수정 완료");
+            })();
+        } catch (err) {
+            console.log(err);
+        }
+    };
+
+    return (
+        <div className="App">
+            <form action="">
+                <ProductImgSetCont htmlFor="productImg">
+                    <textarea
+                        placeholder="게시글 입력하기..."
+                        onChange={handleTextarea}
+                        value={contentText}
+                    />
+
+                    {showImages &&
+                        showImages.map((image, id) => (
+                            <div key={id}>
+                                <img
+                                    src={image}
+                                    alt={`${image}-${id}`}
+                                    ref={imagePre}
+                                />
+                                <span onClick={() => handleDeleteImage(id)}>
+                                    x
+                                </span>
+                            </div>
+                        ))}
+                    <ImgUploadIcon className={"orange small"}>
+                        <span className="ir">이미지 첨부</span>
+                        <input
+                            className="ir"
+                            type="file"
+                            accept="image/*"
+                            onChange={handleAddImages}
+                        />
+                    </ImgUploadIcon>
+                </ProductImgSetCont>
+                <Button
+                    type="submit"
+                    className="ms"
+                    disabled={isBtnDisable}
+                    onClick={onClickUpload}
+                >
+                    업로드
+                </Button>
+            </form>
+        </div>
+    );
+}

--- a/my-app/src/routes/Router.jsx
+++ b/my-app/src/routes/Router.jsx
@@ -7,6 +7,7 @@ import Splash from "../pages/splash/Splash";
 import HomeFeed from "../pages/feed/HomeFeed";
 import PostDetail from "../pages/feed/PostDetail";
 import UploadPost from "../pages/feed/UploadPost";
+import PostEdit from "../pages/feed/PostEdit";
 import UploadProduct from "../pages/feed/UploadProduct";
 import ChatList from "../pages/chat/ChatList";
 import ChattingRoom from "../pages/chat/ChattingRoom";
@@ -38,6 +39,7 @@ export default function Router() {
                 <Route path="/post/" element={<Outlet />}>
                     <Route path="" element={<HomeFeed />} />
                     <Route path=":id/" element={<PostDetail />} />
+                    <Route path=":id/edit" element={<PostEdit />} />
                     <Route path="upload/" element={<UploadPost />} />
                     <Route path="upload/product" element={<UploadProduct />} />
                     <Route path="*" element={<Error />}/>


### PR DESCRIPTION
구현 사항
- 수정 클릭시 모달창 띄움
- 수정 클릭시 게시글 수정 페이지로 이동
- 게시글 수정 페이지에서 처음에 기존 게시글을 가져와야 함
- 수정 API
- textarea에 텍스트도 없고 이미지도 없으면 업로드 버튼 활성화 x

이슈
- 게시글 수정 페이지와 새 게시글 올리는 페이지를 구분했습니다. 그래서 PostEdit 컴포넌트를 하나 만들었고 라우터에서는 /post/:id/edit 위치에 있습니다.
- 이미지를 한 개만 등록한다고 가정하고 코드를 짰습니다. 추후 이미지 여러 개 등록시 코드 수정이 필요합니다.