### PR TITLE
Refactor/issue 178 2022.12.21에 했던 스타일 반응형 구현

### DIFF
--- a/my-app/src/components/CommentInp/commentInp.style.js
+++ b/my-app/src/components/CommentInp/commentInp.style.js
@@ -1,6 +1,10 @@
 import styled from "styled-components";
 
 export const CommentInpCont = styled.form`
+    position: absolute;
+    bottom: 0;
+    width: 100%;
+    background-color: white;
     display: flex;
     border-top: 0.5px solid #dbdbdb;
     /* max-width: 390px; */
@@ -38,5 +42,11 @@ export const CommentInpCont = styled.form`
         flex-shrink: 0;
         margin-left: auto;
         color: ${(props) => (props.isBtnActivated ? "#4583A3" : "#C4C4C4")};
+    }
+
+    @media screen and (min-width: 768px) {
+        & input, button {
+            font-size: 16px;
+        }
     }
 `;

--- a/my-app/src/components/CommentInp/commentInp.style.js
+++ b/my-app/src/components/CommentInp/commentInp.style.js
@@ -1,7 +1,7 @@
 import styled from "styled-components";
 
 export const CommentInpCont = styled.form`
-    position: absolute;
+    position: fixed;
     bottom: 0;
     width: 100%;
     background-color: white;

--- a/my-app/src/components/CommentItem/commentItem.style.js
+++ b/my-app/src/components/CommentItem/commentItem.style.js
@@ -51,4 +51,10 @@ export const CommentItemCont = styled.li`
         top: 0;
         right: 0;
     }
+
+    @media screen and (min-width: 768px){
+        & .comment-main {
+            font-size: 16px;
+        }
+    }
 `;

--- a/my-app/src/components/ImageUpload/imageUpload.style.js
+++ b/my-app/src/components/ImageUpload/imageUpload.style.js
@@ -26,7 +26,7 @@ export const ImgUploadIcon = styled.label`
     }
 
     &.location {
-        position: absolute;
+        position: fixed;
         bottom: 16px;
         right: 16px;
     }

--- a/my-app/src/components/OptionModal/optionModal.style.js
+++ b/my-app/src/components/OptionModal/optionModal.style.js
@@ -2,7 +2,7 @@ import styled from "styled-components";
 import modalIcon from "../../assets/icon/icon-modal.png";
 
 export const OptionLayout = styled.article`
-    max-width: 390px;
+    /* max-width: 390px; */
     width: 100%;
     /* position: absolute; */
     position: fixed;
@@ -24,9 +24,7 @@ export const OptionLayout = styled.article`
     }
 
     & .modal-items > * {
-        padding-top: 14px;
-        padding-bottom: 14px;
-        padding-left: 26px;
+        padding: 14px 26px;
         font-size: 14px;
         font-weight: 400;
         line-height: 18px;
@@ -37,7 +35,19 @@ export const OptionLayout = styled.article`
         width: 100%;
         text-align: left;
         background-color: transparent;
-        font-size: 14px;
+        font-size: 100%;
         line-height: 18px;
+    }
+
+    @media screen and (min-width: 768px){
+
+        & .modal-items > * {
+            font-size: 18px;
+            padding: 18px 30px;
+        }
+
+        & .modal-items > :nth-child(1) {
+            padding-top: 60px;
+        }
     }
 `;

--- a/my-app/src/components/ProductImageSet/productImageSet.style.js
+++ b/my-app/src/components/ProductImageSet/productImageSet.style.js
@@ -21,6 +21,7 @@ export const ProductImgSetCont = styled.label`
     }
 
     & .each-image-cont {
+        display: inline-block;
         position: relative;
         margin-top: 16px;
     }

--- a/my-app/src/components/Textarea/Textarea.jsx
+++ b/my-app/src/components/Textarea/Textarea.jsx
@@ -3,11 +3,12 @@ import styled from "styled-components";
 const Textarea = styled.textarea`
     display: block;
     resize: none;
-    width: calc(100% - 55px);
+    width: calc(100% - 42px);
+    height: 100%;
     // height: auto;
     // /* overflow-y: scroll; */
     // overflow: scroll;
-    padding: 10px;
+    padding: 10px 10px 10px 13px;
     box-sizing: border-box;
     font-size: 14px;
     background-color: none;
@@ -16,6 +17,10 @@ const Textarea = styled.textarea`
     :focus {
         outline: none;
         // border-bottom: 1px solid #DBDBDB;
+    }
+
+    @media screen and (min-width: 768px){
+        font-size: 16px;
     }
 `
 

--- a/my-app/src/components/postEditContentImg.style.js
+++ b/my-app/src/components/postEditContentImg.style.js
@@ -1,0 +1,10 @@
+import styled from "styled-components";
+
+export const Contentimg = styled.img`
+    margin-left: 42px;
+    width: calc(100% - 42px);
+    max-width: 600px;
+    object-fit: cover;
+    border: 0.5px solid #dbdbdb;
+    border-radius: 10px;
+`;

--- a/my-app/src/components/postEditUserProfile.style.js
+++ b/my-app/src/components/postEditUserProfile.style.js
@@ -1,0 +1,10 @@
+import styled from "styled-components";
+
+export const UserProfileImg = styled.img`
+    /* display: inline-block; */
+    float: left;
+    width: 42px;
+    height: 42px;
+    border-radius: 50%;
+    object-fit: cover;
+`;

--- a/my-app/src/components/postEditWrapper.style.js
+++ b/my-app/src/components/postEditWrapper.style.js
@@ -1,0 +1,9 @@
+import styled from "styled-components";
+
+export const PostEditWrapper = styled.div`
+    /* display: flex; */
+    // overflow: hidden;
+    /* height: 100%; */
+    overflow: auto;
+    padding: 20px 16px;
+`;

--- a/my-app/src/pages/chat/ChatList.jsx
+++ b/my-app/src/pages/chat/ChatList.jsx
@@ -5,15 +5,17 @@ import ChatItem from "./chat/ChatItem/ChatItem";
 import NavBar from "../../components/NavBar/NavBar";
 import data from "./chat/chatdata.json";
 
-const Wrapper = styled.div`
-    max-width: 390px;
-    margin: 0 auto;
-`;
-
 const ChatCont = styled.ul`
-    height: 772px;
-    padding: 24px 16px;
-    overflow-y: scroll;
+    /* height: 772px; */
+    padding: 24px 16px 84.5px 16px;
+    /* overflow-y: scroll; */
+
+    @media screen and (min-width: 768px){
+        max-width: 1300px;
+        padding-left: 256px;
+        padding-top: 50px;
+        padding-bottom: 24px;
+    }
 `;
 
 export default function ChatList() {
@@ -44,11 +46,11 @@ export default function ChatList() {
     }, []);
     
     return (
-        <Wrapper>
+        <>
             <TopBar type={"A1"} />
             <h1 className={"ir"}>채팅 리스트</h1>
             <ChatCont>{chatData}</ChatCont>
             <NavBar />
-        </Wrapper>
+        </>
     );
 }

--- a/my-app/src/pages/chat/ChattingRoom.jsx
+++ b/my-app/src/pages/chat/ChattingRoom.jsx
@@ -10,18 +10,14 @@ import Incoming from "./chat/Incoming/Incoming";
 import ChatInput from "./chat/ChatInput/ChatInput";
 import { formattedTimeFunc } from "./dateFormat";
 
-const Wrapper = styled.div`
-    max-width: 390px;
-    margin: 0 auto;
-`;
-
 const ChatContBack = styled.div`
     display: flex;
     flex-direction: column;
     justify-content: flex-end;
-    height: 772px;
+    /* height: 772px; */
+    height: calc(100vh - 60.5px);
     background-color: #f2f2f2;
-    padding: 20px 16px;
+    padding: 20px 16px 60.5px 16px;
 `;
 
 const ChatCont = styled.ul`
@@ -77,7 +73,7 @@ export default function ChattingRoom() {
     };
 
     return (
-        <Wrapper>
+        <>
             {modalVisible && (
                 <OptionModal onConfirm={onConfirm}>
                     <li>
@@ -91,6 +87,6 @@ export default function ChattingRoom() {
                 <ChatCont>{eachChat}</ChatCont>
             </ChatContBack>
             <ChatInput />
-        </Wrapper>
+        </>
     );
 }

--- a/my-app/src/pages/chat/chat/ChatItem/chatItem.style.js
+++ b/my-app/src/pages/chat/chat/ChatItem/chatItem.style.js
@@ -67,4 +67,16 @@ export const ChatItemCont = styled.li`
         line-height: 13px;
         color: #dbdbdb;
     }
+
+    @media screen and (min-width: 768px){
+        margin-bottom: 30px;
+
+        & .userNameAndLastChat .userName {
+            font-size: 16px;
+        }
+
+        & .userNameAndLastChat .lastChat {
+            font-size: 14px;
+        }
+    }
 `;

--- a/my-app/src/pages/chat/chat/Outgoing/outgoing.style.js
+++ b/my-app/src/pages/chat/chat/Outgoing/outgoing.style.js
@@ -12,10 +12,6 @@ export const OutgoingCont = styled.li`
         border-radius: 10px 0 10px 10px;
     }
 
-    & .imgMsg {
-        width: 240px;
-    }
-
     & .time {
         margin-right: 6px;
     }

--- a/my-app/src/pages/chat/chat/sharedStyle.js
+++ b/my-app/src/pages/chat/chat/sharedStyle.js
@@ -6,6 +6,12 @@ const sharedTxtMsg = css`
     font-size: 14px;
     line-height: 18px;
     font-weight: 400;
+
+    @media screen and (min-width: 768px){
+        font-size: 16px;
+        line-height: 20px;
+        padding: 14px;
+    }
 `;
 
 const sharedLayout = css`
@@ -14,6 +20,12 @@ const sharedLayout = css`
 
     &:nth-child(1) {
         margin-top: 0;
+    }
+
+    & .imgMsg {
+        width: 240px;
+        max-height: 600px;
+        object-fit: cover;
     }
 `;
 

--- a/my-app/src/pages/feed/PostDetail.jsx
+++ b/my-app/src/pages/feed/PostDetail.jsx
@@ -13,19 +13,12 @@ import useAuth from "../../hook/useAuth";
 import basicImg from "../../assets/basic-profile-img.png";
 
 const CommentListBox = styled.ul`
-    /* max-width: 390px; */
     border-top: 1px solid #dbdbdb;
-    padding: 20px 16px;
+    padding: 20px 16px 80.5px 16px;
 `;
 
 const PostContentBox = styled.div`
-    /* max-width: 390px; */
     padding: 20px 16px;
-`;
-
-const Wrapper = styled.div`
-    max-width: 390px;
-    margin: 0 auto;
 `;
 
 export default function PostDetail() {
@@ -205,7 +198,7 @@ export default function PostDetail() {
     };
 
     return (
-        <Wrapper>
+        <>
             {modalNotMe && (
                 <OptionModal
                     onConfirm={() => {
@@ -258,7 +251,10 @@ export default function PostDetail() {
                 </PostContentBox>
             )}
             {commentMsg && <CommentListBox>{commentMsg}</CommentListBox>}
-            <CommentInp onSubmit={onCommentSubmitHandle} isBtnActivated={!isBtnDisabled}>
+            <CommentInp
+                onSubmit={onCommentSubmitHandle}
+                isBtnActivated={!isBtnDisabled}
+            >
                 {postMsg && (
                     <img
                         src={data ? data.image : basicImg}
@@ -274,6 +270,6 @@ export default function PostDetail() {
                     게시
                 </button>
             </CommentInp>
-        </Wrapper>
+        </>
     );
 }

--- a/my-app/src/pages/feed/PostEdit.jsx
+++ b/my-app/src/pages/feed/PostEdit.jsx
@@ -1,9 +1,15 @@
 import { useState, useRef, useEffect } from "react";
 import { useLocation } from "react-router-dom";
-import Button from "../../components/Button";
+import TopBar from "../../components/TopBar";
+import Textarea from "../../components/Textarea/Textarea";
 import axios from "axios";
+import { PostEditWrapper } from "../../components/postEditWrapper.style";
+import { Contentimg } from "../../components/postEditContentImg.style";
+import { UserProfileImg } from "../../components/postEditUserProfile.style";
 import { ProductImgSetCont } from "../../components/ProductImageSet/productImageSet.style";
 import { ImgUploadIcon } from "../../components/ImageUpload/imageUpload.style";
+import basicImg from "../../assets/basic-profile-img.png";
+import deleteIcon from "../../assets/icon/icon-delete.png";
 
 export default function PostEdit() {
     const [showImages, setShowImages] = useState([]);
@@ -11,7 +17,10 @@ export default function PostEdit() {
     const [isBtnDisable, setIsBtnDisable] = useState(false);
     const submitData = useRef({});
     const imagePre = useRef(null);
-    const URL = `https://mandarin.api.weniv.co.kr${useLocation().pathname.slice(0, -5)}`;
+    const URL = `https://mandarin.api.weniv.co.kr${useLocation().pathname.slice(
+        0,
+        -5
+    )}`;
 
     // 페이지 로드시 기존 게시글 정보 불러오기 위함
     useEffect(() => {
@@ -148,29 +157,46 @@ export default function PostEdit() {
     };
 
     return (
-        <div className="App">
-            <form action="">
-                <ProductImgSetCont htmlFor="productImg">
-                    <textarea
-                        placeholder="게시글 입력하기..."
-                        onChange={handleTextarea}
-                        value={contentText}
-                    />
+        <>
+            <TopBar
+                type="A4"
+                right4Ctrl={{ form: "postUpload", isDisabled: false }}
+            />
+            <PostEditWrapper>
+                <UserProfileImg
+                    src={basicImg}
+                    alt="게시글 작성자 프로필 사진"
+                />
+                <form action="" id={"postUpload"} onSubmit={onClickUpload}>
+                    <ProductImgSetCont htmlFor="productImg">
+                        <Textarea
+                            placeholder="게시글 입력하기..."
+                            onChange={handleTextarea}
+                            value={contentText}
+                        />
 
-                    {showImages &&
-                        showImages.map((image, id) => (
-                            <div key={id}>
-                                <img
-                                    src={image}
-                                    alt={`${image}-${id}`}
-                                    ref={imagePre}
-                                />
-                                <span onClick={() => handleDeleteImage(id)}>
-                                    x
-                                </span>
-                            </div>
-                        ))}
-                    <ImgUploadIcon className={"orange small"}>
+                        {showImages &&
+                            showImages.map((image, id) => (
+                                <div className="each-image-cont" key={id}>
+                                    <Contentimg
+                                        src={image}
+                                        alt={`${image}-${id}`}
+                                        ref={imagePre}
+                                    />
+                                    <button
+                                        className="delete-btn"
+                                        type="button"
+                                        onClick={() => handleDeleteImage(id)}
+                                    >
+                                        <img
+                                            src={deleteIcon}
+                                            alt="이미지 삭제"
+                                        />
+                                    </button>
+                                </div>
+                            ))}
+                    </ProductImgSetCont>
+                    <ImgUploadIcon className={"orange small location"}>
                         <span className="ir">이미지 첨부</span>
                         <input
                             className="ir"
@@ -179,16 +205,8 @@ export default function PostEdit() {
                             onChange={handleAddImages}
                         />
                     </ImgUploadIcon>
-                </ProductImgSetCont>
-                <Button
-                    type="submit"
-                    className="ms"
-                    disabled={isBtnDisable}
-                    onClick={onClickUpload}
-                >
-                    업로드
-                </Button>
-            </form>
-        </div>
+                </form>
+            </PostEditWrapper>
+        </>
     );
 }

--- a/my-app/src/pages/feed/UploadPost.jsx
+++ b/my-app/src/pages/feed/UploadPost.jsx
@@ -9,27 +9,19 @@ import styled from "styled-components";
 import basicImg from "../../assets/basic-profile-img.png";
 import deleteIcon from "../../assets/icon/icon-delete.png";
 
-const Wrapper = styled.div`
-    position: relative;
-    max-width: 390px;
-    height: 844px;
-    ///* height:100%; */
-    overflow: auto;
-    margin: 0 auto;
-`;
-
 const ContentWrapper = styled.div`
     /* display: flex; */
     // overflow: hidden;
-    height: 100%;
+    /* height: 100%; */
     overflow: auto;
     gap: 12px;
-    margin: 20px 16px;
+    padding: 20px 16px;
 `;
 
 const Contentimg = styled.img`
-    width: 100%;
-    height: 228px;
+    margin-left: 42px;
+    width: calc(100% - 42px);
+    max-width: 600px;
     object-fit: cover;
     border: 0.5px solid #dbdbdb;
     border-radius: 10px;
@@ -147,7 +139,7 @@ export default function UploadPost() {
     };
 
     return (
-        <Wrapper>
+        <>
             <TopBar
                 type="A4"
                 right4Ctrl={{ form: "postUpload", isDisabled: false }}
@@ -196,6 +188,6 @@ export default function UploadPost() {
                     </ImgUploadIcon>
                 </form>
             </ContentWrapper>
-        </Wrapper>
+        </>
     );
 }

--- a/my-app/src/pages/feed/UploadPost.jsx
+++ b/my-app/src/pages/feed/UploadPost.jsx
@@ -1,40 +1,15 @@
 import { useState, useRef } from "react";
 import Button from "../../components/Button";
 import TopBar from "../../components/TopBar";
+import { PostEditWrapper } from "../../components/postEditWrapper.style";
 import { ProductImgSetCont } from "../../components/ProductImageSet/productImageSet.style";
 import { ImgUploadIcon } from "../../components/ImageUpload/imageUpload.style";
+import { UserProfileImg } from "../../components/postEditUserProfile.style";
 import Textarea from "../../components/Textarea/Textarea";
-import styled from "styled-components";
+import { Contentimg } from "../../components/postEditContentImg.style";
 // import {basicImg} from "../../assets/basic-profile-img-small.png";
 import basicImg from "../../assets/basic-profile-img.png";
 import deleteIcon from "../../assets/icon/icon-delete.png";
-
-const ContentWrapper = styled.div`
-    /* display: flex; */
-    // overflow: hidden;
-    /* height: 100%; */
-    overflow: auto;
-    gap: 12px;
-    padding: 20px 16px;
-`;
-
-const Contentimg = styled.img`
-    margin-left: 42px;
-    width: calc(100% - 42px);
-    max-width: 600px;
-    object-fit: cover;
-    border: 0.5px solid #dbdbdb;
-    border-radius: 10px;
-`;
-
-const UserProfileImg = styled.img`
-    /* display: inline-block; */
-    float: left;
-    width: 42px;
-    height: 42px;
-    border-radius: 50%;
-    object-fit: cover;
-`;
 
 export default function UploadPost() {
     const [showImages, setShowImages] = useState([]);
@@ -144,7 +119,7 @@ export default function UploadPost() {
                 type="A4"
                 right4Ctrl={{ form: "postUpload", isDisabled: false }}
             />
-            <ContentWrapper>
+            <PostEditWrapper>
                 <UserProfileImg
                     src={basicImg}
                     alt="게시글 작성자 프로필 사진"
@@ -187,7 +162,7 @@ export default function UploadPost() {
                         />
                     </ImgUploadIcon>
                 </form>
-            </ContentWrapper>
+            </PostEditWrapper>
         </>
     );
 }


### PR DESCRIPTION
Refactor: 챗리스트 페이지 태블릿 반응형 https://github.com/nailedReact/react-app/issues/178
- 채팅이 많아졌을 때 padding-bottom 줌
- 태블릿 버전에서 글씨 크기 키움
- topbar 위에 가득 차도
- 기존에 줬던 height 없앰

Refactor: 개별 채팅방 태블릿 css https://github.com/nailedReact/react-app/issues/178
- 태블릿 이상에서 글씨 크기 키움
- 채팅방 뒷배경 max width 대신 calc(100vh - ~~px) 이용
- 채팅 입력 폼 position: absolute, bottom: 0으로 고정
- inp message output message img 모두에 width 240px

Refactor: 모달창 태블릿 css https://github.com/nailedReact/react-app/issues/178
- 태블릿에서 글씨 크기 키움
- 태블릿에서 li 패딩 키움
- 태블릿에서 모달창의 태블릿 영역을 넓히기 위해 첫 번째 li에만 padding-top을 60px로

Refactor: 게시글 상세 페이지 https://github.com/nailedReact/react-app/issues/178
- 태블릿에서 글씨 키움
- 댓글 입력 position: fixed, bottom: 0
- 특이 사항: postcard는 수현님이 수정하시는거 같아 css 수정 안 했습니다

Refactor: 게시물 업로드 페이지 CSS 태블릿 https://github.com/nailedReact/react-app/issues/178
- textarea height 100%를 통해 textarea의 height가 너무 커지는걸 방지: 다른 곳에서도 잘 작동하는지 확인 필요
- 글씨 크기 키움
- 레이아웃 피그마에 맞춤
- 이미지 업로드 아이콘 fixed bottom

Style: 게시물 수정 페이지 CSS https://github.com/nailedReact/react-app/issues/178
- 게시물 업로드 페이지랑 수정 페이지랑 공통되는 컴포넌트 따로 컴포넌트 빼서 컴포넌트 폴더 하에 넣어놓음
- 업로드 활성화 버튼 탑바랑 연결하는 거 추후 구현 필요