### PR TITLE
Etc/issue 220

### DIFF
--- a/my-app/src/components/PostCard.jsx
+++ b/my-app/src/components/PostCard.jsx
@@ -24,6 +24,7 @@ const Cont = styled.div`
 const Username = styled.h2`
     font-weight: 500;
     font-size: 14px;
+    cursor: pointer;
     @media screen and (min-width: 768px){
         font-size: 16px;
     }
@@ -35,6 +36,7 @@ const Accountname = styled.p`
     line-height: 14px;
     color: #767676;
     margin-top: 2px;
+    cursor: pointer;
     @media screen and (min-width: 768px){
         font-size: 14px;
     }
@@ -81,6 +83,7 @@ const HeartCommentCont = styled.div`
     display: flex;
     align-items: center;
     margin-right: 16px;
+    cursor: pointer;
 `;
 const HeartCommentimg = styled.img`
     width: 15px;
@@ -109,6 +112,7 @@ const ProfilePicSmall = styled.img`
     @media screen and (min-width: 768px){
         margin-right: 16px;
     }
+    cursor: pointer;
 `;
 
 const Plusbutton = styled.button`

--- a/my-app/src/components/TopBar.jsx
+++ b/my-app/src/components/TopBar.jsx
@@ -31,7 +31,11 @@ const LeftCont = styled.div`
     align-items: center;
 
 `
-const RightCont = styled.div``
+const RightCont = styled.div`
+    display: flex;
+    width: 50%;
+    justify-content: right;
+`
 
 const BtnIcon = styled.button`
     ${({action}) => action === "back" && css`
@@ -50,6 +54,7 @@ const BtnIcon = styled.button`
     width: 24px;
     height: 24px;
 `;
+
 const SearchBtn = styled.button`
     background: url(${iconSearch});
     background-position: center;
@@ -60,31 +65,29 @@ const SearchBtn = styled.button`
     right: 10px;
     top: 17px;
 `;
-    const Searchinput = styled.input`
-    position: absolute;
-        font-size: 14px;
-        line-height: 18px;
-        background: #F2F2F2;
-        border-radius: 32px;
-        border: 0;
-        height: 32px;
-        width: 70%;
-        top: 10px;
-        right: 10px;
-        padding-left: 10px;
-        margin-right: 30px;
-
-    `;
-    const LogoCont = styled.div`
-    background: url(${Logo});
-    background-size: cover;
-    width: 162px;
-    height: 40px;
-    @media screen and (max-width: 768px){
-        display: none;
+const Searchinput = styled.input`
+    font-size: 14px;
+    background: #F2F2F2;
+    border-radius: 30px;
+    border: none;
+    padding: 8px 80px 8px 8px;
+    transition: .5s;
+    width: inherit;
+    &:focus {
+        width: 100%;
     }
-    cursor: pointer;
-    `
+`;
+
+const LogoCont = styled.div`
+background: url(${Logo});
+background-size: cover;
+width: 162px;
+height: 40px;
+@media screen and (max-width: 768px){
+    display: none;
+}
+cursor: pointer;
+`
 
 export default function TopBar({type, title, right4Ctrl, onChangeByUpper, onClickGetMsg, onClickModal}) {
     // type의 앞글자, type의 뒤의 글자를 변수에 저장한다.

--- a/my-app/src/pages/chat/chat/ChatItem/ChatItem.jsx
+++ b/my-app/src/pages/chat/chat/ChatItem/ChatItem.jsx
@@ -2,7 +2,12 @@ import React from "react";
 import { Link } from "react-router-dom";
 import { ChatItemCont } from "./chatItem.style";
 import { formattedDateFunc } from "../../dateFormat";
+import styled from "styled-components";
 
+const ProfilePic = styled.img`
+    border: 0.5px solid #C4C4C4;
+    border-radius: 50%;
+`
 export default function ChatItem({
     linkSrc,
     image,
@@ -23,7 +28,7 @@ export default function ChatItem({
                 <div className={isOnline ? "profileImgWrapper online" : "profileImgWrapper"}>
                     {/* 스크린 리더 사용자를 위해 온라인 오프라인 표시를 했습니다. */}
                     <span className={"ir"}>{isOnline ? "온라인" : "오프라인"}</span>
-                    <img className={"profileImg"} src={image} alt="프로필 사진" />
+                    <ProfilePic className={"profileImg"} src={image} alt="프로필 사진" />
                 </div>
                 <div className={"userNameAndLastChat"}>
                     <h2 className={"userName"}>{username}</h2>

--- a/my-app/src/pages/feed/FeedNoFollower.jsx
+++ b/my-app/src/pages/feed/FeedNoFollower.jsx
@@ -9,21 +9,25 @@ const FeedNoFollower = () => {
     const Symbolimg = styled.img`
         width: 120px;
         height: 120px;
-        margin-top: 225px;
     `;
 
     const SearchText = styled.p`
         font-style: normal;
         font-weight: 400;
         font-size: 14px;
-        line-height: 14px;
         color: #767676;
-        margin: 25px 0px;
     `;
 
     const Cont = styled.div`
-        text-align: center;
-        height: 100%;
+        display: flex;
+        height: calc(100vh - 60px);
+        flex-direction: column;
+        justify-content: center;
+        align-items: center;
+        gap: 20px;
+        @media screen and (max-width: 768px){
+            height: calc(100vh - 60px - 55px);
+        }
     `;
 
     const navigate = useNavigate();

--- a/my-app/src/pages/feed/HomeFeed.jsx
+++ b/my-app/src/pages/feed/HomeFeed.jsx
@@ -9,6 +9,7 @@ import NavBar from "../../components/NavBar/NavBar";
 import {
   FeedCont
 } from "./homeFeed.style"
+import Loading from "../error/Loading";
 
 /* eslint-disable */
 

--- a/my-app/src/pages/feed/homeFeed.style.js
+++ b/my-app/src/pages/feed/homeFeed.style.js
@@ -3,11 +3,8 @@ import styled from "styled-components";
 export const FeedCont = styled.div`
     display: flex;
     flex-direction: column;
-    /* justify-content: center; */
-    /* align-items: center; */
     background-color: #F2F2F2;
-    /* gap: 10px; */
-
+    /* height: calc(100vh - 60px); */
     @media screen and (max-width: 768px){
         padding-bottom: 60px;
     }

--- a/my-app/src/pages/profile/userprofile/ProfileCard.jsx
+++ b/my-app/src/pages/profile/userprofile/ProfileCard.jsx
@@ -25,6 +25,8 @@ import { UserNameContext } from "./Profile"
   const Profileimg = styled.img`
     height: 110px;
     width: 110px;
+    border-radius: 50%;
+    outline: 1px solid #C4C4C4;
   `;
 
   const Username = styled.h2`
@@ -100,8 +102,11 @@ export default function ProfileCard() {
     const [checkFollowing, setCheckFollowing] = useState(profileData.isfollow)
     const navigate = useNavigate();
     const { username, isMyProfile } = useContext(UserNameContext);
-    // console.log(isMyProfile)
     const [temp, setTemp] = useState(1);
+
+    useEffect(() => {
+      setCheckFollowing(profileData.isfollow)
+    }, [profileData])
 
     useEffect(() => {
         const getprofile = async () => {
@@ -109,7 +114,6 @@ export default function ProfileCard() {
           const res = await axios.get(URL, {
             headers: {
               Authorization : localStorage.getItem("Authorization")
-              // Authorization: "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjYzOTY5MWQwMTdhZTY2NjU4MWMzMjM1YyIsImV4cCI6MTY3NTk5NjE5MywiaWF0IjoxNjcwODEyMTkzfQ.yX_F68SQOJkak0ud8BUTI3OUHriaIlPqEqDUiWBcf6I"
             }
         });
         setProfileData(res.data.profile);
@@ -146,6 +150,7 @@ export default function ProfileCard() {
           setCheckFollowing(true);
       }
     }
+
   return (
     <Cont>
       <ProfileCont>
@@ -174,7 +179,7 @@ export default function ProfileCard() {
           <Button className='medium' onClick={()=> navigate("./edit/")}>프로필 수정</Button>
           <Button className='medium' onClick={()=> navigate("../../post/upload/product")}>상품등록</Button>
           </> :
-          <Button className='medium' active={!checkFollowing} value={checkFollowing} onClick={followingchange}>{checkFollowing ? "취소" : "팔로우"}</Button>}
+          <Button className='medium' active={!checkFollowing} value={checkFollowing} onClick={followingchange}>{checkFollowing ? "팔로우 취소" : "팔로우"}</Button>}
           <Shareimg src={share} alt="공유하기" onClick={()=> {chatorshare("share")}}/>
         </ButtonCont>
     </Cont>


### PR DESCRIPTION
-  다른 사람 프로필 조회 시 팔로우 중인데 팔로우 버튼이 활성화되어 있는 이슈 해결
    <img width="312" alt="image" src="https://user-images.githubusercontent.com/78977003/209517041-a2aaf32e-af00-4285-abfe-019714699b83.png">

-  클릭되는 영역인데 커서가 pointer로 되어있지 않은 부분 수정
    <img width="485" alt="image" src="https://user-images.githubusercontent.com/78977003/209517140-b7750c1e-53a1-4e85-a9b8-a9a2c0b04353.png">

    - 프로필 카드의 프로필 사진
    - 프로필 카드의 계정이름, 사용자 이름
    - 프로필 카드 좋아요

-  상단바 검색창 디자인 수정
    - before (검색창 상하단 여백이 맞지 않음)
    <img width="930" alt="image" src="https://user-images.githubusercontent.com/78977003/209516905-ca41e673-4604-4648-b312-496f72c35ebc.png">

    - after
    <img width="1189" alt="image" src="https://user-images.githubusercontent.com/78977003/209517697-e2d77e1d-1c3c-4d47-aaee-96a840412b3e.png">
 
    - active
    <img width="1187" alt="image" src="https://user-images.githubusercontent.com/78977003/209517769-94af2436-8762-4691-950f-9f402c9a1448.png">

-  채팅 프로필 이미지 동그랗게, 보더 설정
    - before 
    <img width="633" alt="image" src="https://user-images.githubusercontent.com/78977003/209517317-c58007be-a8e7-4139-9d41-45e55a8de129.png">

    - after
    <img width="912" alt="image" src="https://user-images.githubusercontent.com/78977003/209517637-1464c2ea-2c8c-467d-86ce-511f9f483eb6.png">

- 팔로워 없을 때 이미지 전체 높이로 채우기
    - before
    <img width="1184" alt="image" src="https://user-images.githubusercontent.com/78977003/209517396-962b1720-f382-4d7c-9f28-2b8a08f515d4.png">

    - after
    <img width="1440" alt="image" src="https://user-images.githubusercontent.com/78977003/209517592-7b1b6cfa-c55c-46ce-be8b-ea1a54688ca5.png">

