### PR TITLE
Fix: 게시물 상세 페이지 댓글 시간 음수 문제 #222

### DIFF
--- a/my-app/src/pages/feed/feed/dateformat.js
+++ b/my-app/src/pages/feed/feed/dateformat.js
@@ -15,7 +15,7 @@ export const formattedDate = (date) => {
         } else if (Math.floor(diff / (60 * 1000)) > 0) {
             res = `${Math.floor(diff / (60 * 1000))}분 전`;
         } else {
-            if (Math.floor(diff / 1000) === -1) {
+            if (Math.floor(diff / 1000) < 0) {
                 res = "0초 전";
             } else {
                 res = `${Math.floor(diff / 1000)}초 전`;


### PR DESCRIPTION
- #206에서 -1부터 시작할 때만 처리함
- #212 테스트 중 -1뿐만 아니라 -2, -3도 나올 수 있는거 파악
- 예외 처리를 -1뿐만 아니라 모든 음수에서 하도록 처리
- 한계점: 왜 음수가 나오는지 파악하지 않음