### PR TITLE
Fix: 모바일 입력창 확대 효과 제거 #278

### DIFF
--- a/my-app/public/index.html
+++ b/my-app/public/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
-    <meta name="viewport" content="width=device-width, initial-scale=1 user-scalable=0">
+    <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no, maximum-scale=1" />
     <meta name="theme-color" content="#4583A3" />
     <meta
       name="description"


### PR DESCRIPTION
![IMG_0776](https://user-images.githubusercontent.com/78977003/209757163-66a91bc9-8b1b-4cbc-acc5-ad85b80038c2.jpg)

모바일 기기에서 입력창에 포커싱될 때 화면 전체가 확대되는 문제가 있었음
index.html 의 head에서
```<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no, maximum-scale=1" />```
meta 태그를 다음과 같이 설정해줌으로써 해결