### PR TITLE
Fix: 게시물 수정시 텍스트 에리어 높이 문제 #327

### DIFF
--- a/my-app/src/components/Textarea/Textarea.jsx
+++ b/my-app/src/components/Textarea/Textarea.jsx
@@ -2,9 +2,11 @@ import styled from "styled-components";
 
 const Textarea = styled.textarea`
     display: block;
-    /* resize: none; */
+    resize: none;
     width: calc(100% - 42px);
-    height: 100%;
+    /* min-height: 100px; */
+    overflow: hidden;
+    /* height: 100%; */
     font-family: "Pretendard";
     padding: 10px 10px 10px 13px;
     box-sizing: border-box;

--- a/my-app/src/pages/feed/PostEdit.jsx
+++ b/my-app/src/pages/feed/PostEdit.jsx
@@ -59,6 +59,10 @@ export default function PostEdit() {
                 // textarea 기존 데이터 받아온 거로
                 setContentText(res.data.post.content);
 
+                const rows = res.data.post.content.split(/\r\n|\r|\n/).length;
+
+                textarea.current.style.height= (rows * 18) + "px";
+
                 setShowImages((prev) => {
                     // 받아온 기존 데이터에 이미지가 있을 경우에만 이미지 렌더링
                     if (res.data.post.image) {
@@ -77,38 +81,10 @@ export default function PostEdit() {
         // eslint-disable-next-line
     }, []);
 
-    const rows = useRef();
-
-    useEffect(() => {
-        const newRows = textarea.current.value.split(/\r\n|\r|\n/).length;
-
-        console.log(`예전 rows: ${rows.current}`);
-        console.log(`새로운 rows: ${newRows}`);
-
-        if (rows.current !== newRows) {
-            rows.current = newRows;
-            console.log("rows 업데이트");
-
-            if (textarea.current.scrollHeight > textarea.current.clientHeight) {
-                //textarea height 확장
-                textarea.current.style.height = textarea.current.scrollHeight + "px";
-            } else {
-                //textarea height 축소
-                // textarea.current.style.height =
-                // textarea.current.scrollHeight - 18 + "px";
-
-                textarea.current.style.height= (rows.current * 18) + "px";
-            }
-        } else {
-            textarea.current.style.height = "auto";
-            textarea.current.style.height = textarea.current.scrollHeight + "px";
-        }
-    }, [contentText]);
-
     const handleTextarea = (e) => {
         setContentText(e.target.value);
-        // textarea.current.style.height = "auto";
-        // textarea.current.style.height = textarea.current.scrollHeight + "px";
+        textarea.current.style.height = "auto";
+        textarea.current.style.height = textarea.current.scrollHeight + "px";
         if (e.target.value.length === 0 && showImages.length === 0) {
             setIsBtnDisable(true);
         } else {


### PR DESCRIPTION
- 문제점: 텍스트 에리어가 데이터를 받아오기 전엔 높이가 없지만 데이터를 받아온 뒤에는 데이터에 맞게 높이를 늘려야 함. 이 문제를 해결하기 위해 코드를 짰으나(#325) 제대로 해결하지 못함
- 해결 방법: 텍스트에리어 내 텍스트 렌더링을 담당하는 state의 변화에 따라 동작하던 useEffect를 사용하는 거 대신, 데이터를 받아온 뒤 그 응답결과의 줄 수를 계산해 ref를 이용해 바로 텍스트에리어의 높이를 늘림. 이후 텍스트에리어에 change 이벤트가 일어날 때마다 성준님이 기존에 짜신 텍스트에리어 자동 높이 조절 코드가 동작하도록 함