### PR TITLE
Fix: 게시물 수정 텍스트에리어 높이 버그 #335

### DIFF
--- a/my-app/src/pages/feed/PostEdit.jsx
+++ b/my-app/src/pages/feed/PostEdit.jsx
@@ -63,7 +63,7 @@ export default function PostEdit() {
 
                 const rows = res.data.post.content.split(/\r\n|\r|\n/).length;
 
-                textarea.current.style.height= (rows * 18) + "px";
+                textarea.current.style.height= res.data.post.content.length ? (rows * 18) + "px" : "37px";
 
                 setShowImages((prev) => {
                     // 받아온 기존 데이터에 이미지가 있을 경우에만 이미지 렌더링
@@ -106,34 +106,6 @@ export default function PostEdit() {
     const handleBlur = () => {
         setIsFocused(false);
     }
-
-    const rows = useRef();
-
-    useEffect(() => {
-        const newRows = textarea.current.value.split(/\r\n|\r|\n/).length;
-
-        console.log(`예전 rows: ${rows.current}`);
-        console.log(`새로운 rows: ${newRows}`);
-
-        if (rows.current !== newRows) {
-            rows.current = newRows;
-            console.log("rows 업데이트");
-
-            if (textarea.current.scrollHeight > textarea.current.clientHeight) {
-                //textarea height 확장
-                textarea.current.style.height = textarea.current.scrollHeight + "px";
-            } else {
-                //textarea height 축소
-                // textarea.current.style.height =
-                // textarea.current.scrollHeight - 18 + "px";
-
-                textarea.current.style.height= (rows.current * 18) + "px";
-            }
-        } else {
-            textarea.current.style.height = "auto";
-            textarea.current.style.height = textarea.current.scrollHeight + "px";
-        }
-    }, [contentText]);
 
     const handleTextarea = (e) => {
         setContentText(e.target.value);


### PR DESCRIPTION
- 줄 수로 처음에 계산했기 때문에, 아무 글이 없는 게시글 로딩시 텍스트에리어의 높이가 0이 되면서 플레이스홀더가 짤림 => 게시글 텍스트 length 없을 경우 37px로
- 높이가 왔다갔다 하는 현상 => 불필요한 useEffect 있었기 때문 => 해당 코드 제거