### PR TITLE
Fix: 게시물 작성/수정시 텍스트에리어 값은 비어있지 않지만 줄바꿈이 없는 한줄일 때 플레이스 홀더 잘림 #333

### DIFF
--- a/my-app/src/pages/feed/PostEdit.jsx
+++ b/my-app/src/pages/feed/PostEdit.jsx
@@ -23,7 +23,7 @@ let alreadySubmitted = []; // 화면에 띄운 거 중 새로 업로드한 파�
 
 export default function PostEdit() {
     const [showImages, setShowImages] = useState([]);
-    const [contentText, setContentText] = useState("");
+    // const [contentText, setContentText] = useState("");
     const [isBtnDisable, setIsBtnDisable] = useState(false);
     const [isFocused, setIsFocused] = useState();
     const imagePre = useRef(null);
@@ -58,12 +58,10 @@ export default function PostEdit() {
                     },
                 });
 
-                // textarea 기존 데이터 받아온 거로
-                setContentText(res.data.post.content);
+                textarea.current.value = res.data.post.content;
 
-                const rows = res.data.post.content.split(/\r\n|\r|\n/).length;
-
-                textarea.current.style.height= res.data.post.content.length ? (rows * 18) + "px" : "37px";
+                textarea.current.style.height = "auto";
+                textarea.current.style.height = textarea.current.scrollHeight + "px";
 
                 setShowImages((prev) => {
                     // 받아온 기존 데이터에 이미지가 있을 경우에만 이미지 렌더링
@@ -108,7 +106,7 @@ export default function PostEdit() {
     }
 
     const handleTextarea = (e) => {
-        setContentText(e.target.value);
+        // setContentText(e.target.value);
         textarea.current.style.height = "auto";
         textarea.current.style.height = textarea.current.scrollHeight + "px";
         if (e.target.value.length === 0 && showImages.length === 0) {
@@ -152,7 +150,7 @@ export default function PostEdit() {
     const handleDeleteImage = (id) => {
         setShowImages(showImages.filter((_, index) => index !== id));
 
-        if (!contentText && showImages.length === 1) {
+        if (!textarea.current.value && showImages.length === 1) {
             setIsBtnDisable(true);
         }
 
@@ -216,7 +214,7 @@ export default function PostEdit() {
 
             const productData = {
                 post: {
-                    content: contentText,
+                    content: textarea.current.value,
                     image: submitOnProfileEdit,
                 },
             };
@@ -267,7 +265,6 @@ export default function PostEdit() {
                         <Textarea
                             placeholder="게시글 입력하기..."
                             onChange={handleTextarea}
-                            value={contentText}
                             ref={textarea}
                             onFocus={handleFocus}
                             onBlur={handleBlur}

--- a/my-app/src/pages/feed/UploadPost.jsx
+++ b/my-app/src/pages/feed/UploadPost.jsx
@@ -19,7 +19,6 @@ let fileUrls = [];
 export default function UploadPost() {
     const [isBtnDisable, setIsBtnDisable] = useState(true);
     const [showImages, setShowImages] = useState([]);
-    const [contentText, setContentText] = useState("");
     const [isFocused, setIsFocused] = useState();
     const imagePre = useRef(null);
     const textarea = useRef();
@@ -64,7 +63,6 @@ export default function UploadPost() {
 
     // textarea 자동 높이 조절
     const handleTextarea = (e) => {
-        setContentText(e.target.value);
         textarea.current.style.height = "auto";
         textarea.current.style.height = textarea.current.scrollHeight + "px";
         if (e.target.value.length === 0 && showImages.length === 0) {
@@ -117,7 +115,7 @@ export default function UploadPost() {
     const handleDeleteImage = (id) => {
         setShowImages(showImages.filter((_, index) => index !== id));
 
-        if (!contentText && showImages.length === 1) {
+        if (!textarea.current.value && showImages.length === 1) {
             setIsBtnDisable(true);
         };
 
@@ -166,7 +164,7 @@ export default function UploadPost() {
 
             const productData = {
                 post: {
-                    content: contentText,
+                    content: textarea.current.value,
                     image: imgUrls.join(","),
                 },
             };
@@ -231,7 +229,6 @@ export default function UploadPost() {
                         <Textarea
                             placeholder="게시글 입력하기..."
                             onChange={handleTextarea}
-                            value={contentText}
                             ref={textarea}
                             onFocus={handleFocus}
                             onBlur={handleBlur}


### PR DESCRIPTION
- 해결 방법: 기존의 텍스트에리어 useState를 사용하는 방식에서 이미 ref가 텍스트에리어에 걸려있으므로 데이터를 받아온 뒤, 텍스트에리어의 value에 받아온 데이터를 넣고 성준님 방법으로 길이를 늘림(기존의 줄 계산 방식 사용 x)

- 이 이슈를 해결하는 과정에서 새로 발견한 문제점
1. 한줄로 길게 입력시 게시글 수정/업로드 후 프로필 페이지에서 줄바꿈이 일어나지 않아 영역을 벗어나 보임
2. 프로필 페이지에서 게시글 삭제 후 계속 프로필 페이지에 머무르는 것이 아닌, 다른 페이지로 가버림(예전에 게시글 상세 페이지에서 모달창 작업을 할 때, 모달창에서 삭제 버튼 클릭 후 게시글 상세 페이지가 더 이상 존재하지 않으므로 다른 페이지로 가도록 처리했는데, 컴포넌트가 겹치면서 발생하는 문제일 수 있을듯)
3. 프로필 페이지에서 게시글 삭제시 토스트 메시지 Cannot read properties of null (reading 'style') 에러가 콘솔에 뜬다
4. 게시글 삭제시 요청이 두 번 가는 거로 보임 - 이미 삭제를 한 뒤 다시 또 그걸 삭제하려고 하는듯
<img width="544" alt="스크린샷 2022-12-30 오후 7 55 43" src="https://user-images.githubusercontent.com/104843477/210062700-b22820b5-2c52-4b34-981f-711a7f3a80b9.png">

